### PR TITLE
Remove time scale and use time scale unit from VCS parameter instead.…

### DIFF
--- a/test/clk_mux_glitch_free_tb.sv
+++ b/test/clk_mux_glitch_free_tb.sv
@@ -20,8 +20,8 @@
 `define min(a,b) (((a) < (b))? (a) : (b))
 
 module clk_mux_glitch_free_tb;
-  timeunit 1ns;
-  timeprecision 1ps;
+  // timeunit 1ns;
+  // timeprecision 1ps;
 
   parameter int unsigned NUM_INPUTS = 10;
   localparam int unsigned SEL_WIDTH = $clog2(NUM_INPUTS);


### PR DESCRIPTION
… This will avoid VCS error while building simulation binary on chiplet repo.